### PR TITLE
Performance Fix + Minor Improvement

### DIFF
--- a/src/components/Graph/AnalysisWindow/Content/tabs/ExposureTab/EntityView.tsx
+++ b/src/components/Graph/AnalysisWindow/Content/tabs/ExposureTab/EntityView.tsx
@@ -39,7 +39,12 @@ const AddressRow: FC<AddressRowProps> = ({ address }) => {
 
   return (
     <li className="flex w-full items-center space-x-3" key={address.hash}>
-      <div className="flex w-full flex-row items-center justify-between rounded-md p-2 transition-all duration-100 hover:bg-gray-100">
+      <div
+        className="flex w-full cursor-pointer flex-row items-center justify-between rounded-md p-2 transition-all duration-100 hover:bg-gray-100"
+        onClick={() => {
+          expand();
+        }}
+      >
         <div className="flex items-center gap-x-2 text-xs text-gray-500">
           <HashtagIcon className="h-7 w-7 text-gray-300" />
           <span className="flex-col items-center space-y-1">
@@ -51,7 +56,7 @@ const AddressRow: FC<AddressRowProps> = ({ address }) => {
             </p>
           </span>
         </div>
-        <BigButton text="Expand" Icon={ShareIcon} onClick={expand} />
+        <BigButton text="Expand" Icon={ShareIcon} onClick={() => {}} />
       </div>
     </li>
   );

--- a/src/components/Graph/AnalysisWindow/Overview/Overview.tsx
+++ b/src/components/Graph/AnalysisWindow/Overview/Overview.tsx
@@ -1,4 +1,11 @@
-import { FC, useState, useContext, useCallback, useMemo } from "react";
+import {
+  FC,
+  useState,
+  useContext,
+  useCallback,
+  useMemo,
+  useEffect,
+} from "react";
 import {
   ArrowDownLeftIcon,
   ArrowUpRightIcon,
@@ -17,9 +24,10 @@ import BigButton from "../../../common/BigButton";
 import EntityLogo from "../../../common/EntityLogo";
 import Badge from "../../../common/Badge";
 
-import "../Scrollbar.css";
-
 import { GraphContext } from "../../Graph";
+import { AnalysisContext } from "../../custom_elements/nodes/AddressNode/AddressNode/AddressNode";
+
+import "../Scrollbar.css";
 
 /** There can be 3 incoming states for an entity row:
  * - **Outgoing**: The address is sending funds to the entity
@@ -105,6 +113,12 @@ const EntityRow: FC<EntityRowProps> = ({
   // TODO - Import the path expansion method from the graph
   const [expandedPaths, setExpandedPaths] = useState<number>(0);
   const { addAddressPaths } = useContext(GraphContext);
+  const { analysisData } = useContext(AnalysisContext);
+
+  // Whenever analysisData changes, reset the expanded paths
+  useEffect(() => {
+    setExpandedPaths(0);
+  }, [analysisData]);
 
   const expandPath = useCallback(() => {
     if (expandedPaths < paths.length) {
@@ -270,12 +284,14 @@ const Overview: FC = () => {
             style={{
               transitionDelay: `${index * (100 - index / 10)}ms`,
             }}
+            key={row.entity + focusedAddressData.address}
           >
             <EntityRow
               entity={row.entity}
               totalIncoming={row.totalIncoming}
               totalOutgoing={row.totalOutgoing}
               paths={row.paths}
+              key={row.entity + focusedAddressData.address}
             />
           </Transition>
         ))}

--- a/src/components/Graph/AnalysisWindow/Overview/Overview.tsx
+++ b/src/components/Graph/AnalysisWindow/Overview/Overview.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useEffect,
 } from "react";
+import clsx from "clsx";
 import {
   ArrowDownLeftIcon,
   ArrowUpRightIcon,
@@ -191,7 +192,10 @@ const EntityRow: FC<EntityRowProps> = ({
         if (!showExpandButton) return;
         expandPath();
       }}
-      className="flex w-full cursor-pointer flex-row items-center justify-between rounded-md p-2 transition-all duration-100 hover:bg-gray-100"
+      className={clsx(
+        "flex w-full flex-row items-center justify-between rounded-md p-2 transition-all duration-100",
+        showExpandButton && "hover:cursor-pointer hover:bg-gray-100",
+      )}
     >
       <span className="flex flex-row items-center gap-x-3">
         <EntityLogo entity={entity} className="h-12 w-12 rounded-full" />
@@ -281,6 +285,7 @@ const Overview: FC = () => {
             leave="transition-all ease-in-out transform duration-300 origin-left"
             leaveFrom="translate-y-0 opacity-100 scale-100"
             leaveTo="-translate-x-10 -translate-y-3 opacity-0 scale-50"
+            className="mr-2"
             style={{
               transitionDelay: `${index * (100 - index / 10)}ms`,
             }}

--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -400,8 +400,13 @@ const GraphProvided: FC<GraphProvidedProps> = ({
       setNodes(newNodes);
       setEdges(newEdges);
     },
-    [nodes, edges],
+    [nodes.length, edges.length],
   );
+
+  // useEffect: Whenever addAddressPaths changes, log it
+  useEffect(() => {
+    console.log("addAddressPaths changed");
+  }, [addAddressPaths]);
 
   const addEdges = useCallback(
     (newEdges: Edge[]) => {


### PR DESCRIPTION
- Fixed bug causing infinite re-renders to happen at every step
- Expand row in analysis mode now works for the entire row instead of just the button
- Fixed bug causing entity row in overview mode to "remember number of nodes expanded" between addresses due to having the same key values. No longer happens.